### PR TITLE
adds a space in the copy

### DIFF
--- a/ui/src/components/VerifyIdentityToken.tsx
+++ b/ui/src/components/VerifyIdentityToken.tsx
@@ -86,7 +86,7 @@ const VerifyIdentityToken: FC<Props> = ({ info }) => {
         <div className="category-link">
           Pomerium adds a signed JWT token to the incoming request headers (
           <code>X-Pomerium-Jwt-Assertion</code>) which can then be used to
-          assert a
+          assert a &nbsp;
           <a href="https://www.pomerium.com/docs/topics/getting-users-identity.html#verification">
             user's identity details
           </a>


### PR DESCRIPTION
Currently:
![image](https://user-images.githubusercontent.com/2349184/149218531-01c01f3c-b8f8-48a2-b058-914984a95d06.png)

I haven't tested this, so it needs to be confirmed that it renders correctly.