### PR TITLE
allow invalid certificates for HTTP requests, add TLS verification information to request

### DIFF
--- a/http.go
+++ b/http.go
@@ -25,9 +25,16 @@ import (
 var uiFS embed.FS
 
 func (srv *Server) initRouter() {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.DialTLSContext = srv.tlsVerifier.DialTLSContext
+	client := &http.Client{
+		Transport: transport,
+	}
+
 	verifier, err := sdk.New(&sdk.Options{
-		Datastore: NewCache(1024),
-		Logger:    stdlog.New(log.With().Logger(), "", 0),
+		Datastore:  NewCache(1024),
+		HTTPClient: client,
+		Logger:     stdlog.New(log.With().Logger(), "", 0),
 	})
 	if err != nil {
 		log.Fatal().Err(err).Send()
@@ -111,6 +118,7 @@ func (srv *Server) serveAPIVerifyInfo(w http.ResponseWriter, r *http.Request) {
 			"url":      r.URL.RequestURI(),
 			"host":     r.Host,
 			"hostname": getHostname(),
+			"tlsValid": srv.tlsVerifier.IsValid(r),
 		},
 		"headers": getPomeriumHeaders(r),
 	}

--- a/tls.go
+++ b/tls.go
@@ -1,0 +1,92 @@
+package verify
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/rs/zerolog/log"
+)
+
+type tlsVerifier struct {
+	mu    sync.Mutex
+	valid map[string]struct{}
+}
+
+func newTLSVerifier() *tlsVerifier {
+	return &tlsVerifier{valid: make(map[string]struct{})}
+}
+
+func (v *tlsVerifier) DialTLSContext(ctx context.Context, network, addr string) (net.Conn, error) {
+	dialer := &net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+		DualStack: true,
+	}
+	log.Info().Str("addr", addr).Msg("dialing")
+	conn, err := tls.DialWithDialer(dialer, network, addr, &tls.Config{
+		InsecureSkipVerify: true,
+		ServerName:         tlsHost(addr),
+		VerifyPeerCertificate: func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
+			return v.VerifyPeerCertificate(tlsHost(addr), rawCerts)
+		},
+	})
+	if err != nil {
+		log.Error().Err(err).Str("addr", addr).Msg("error dialing TLS")
+		return nil, err
+	}
+	return conn, nil
+}
+
+func (v *tlsVerifier) VerifyPeerCertificate(serverName string, rawCerts [][]byte) error {
+	certs := make([]*x509.Certificate, len(rawCerts))
+	for i, rawCert := range rawCerts {
+		var err error
+		certs[i], err = x509.ParseCertificate(rawCert)
+		if err != nil {
+			log.Error().Err(err).Msg("error parsing TLS certificate")
+			return err
+		}
+	}
+
+	opts := x509.VerifyOptions{
+		DNSName:       serverName,
+		Intermediates: x509.NewCertPool(),
+	}
+	for _, cert := range certs[1:] {
+		opts.Intermediates.AddCert(cert)
+	}
+	_, err := certs[0].Verify(opts)
+	v.mu.Lock()
+	if err == nil {
+		v.valid[serverName] = struct{}{}
+	} else {
+		delete(v.valid, serverName)
+	}
+	v.mu.Unlock()
+	return nil
+}
+
+func (v *tlsVerifier) IsValid(r *http.Request) bool {
+	if r == nil || r.TLS == nil {
+		return false
+	}
+
+	v.mu.Lock()
+	_, ok := v.valid[r.TLS.ServerName]
+	v.mu.Unlock()
+
+	return ok
+}
+
+func tlsHost(targetAddr string) string {
+	if strings.LastIndex(targetAddr, ":") > strings.LastIndex(targetAddr, "]") {
+		targetAddr = targetAddr[:strings.LastIndex(targetAddr, ":")]
+	}
+	return targetAddr
+}

--- a/ui/dist/index.css
+++ b/ui/dist/index.css
@@ -193,6 +193,10 @@ a:hover {
   background: #e25950;
 }
 
+.status-warn {
+  background: rgb(237 108 4);
+}
+
 /******* Clearfix *******/
 
 .clearfix:after {

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -6,6 +6,7 @@ export type VerifyInfoRequest = {
   method: string;
   origin: string;
   url: string;
+  tlsValid: boolean;
 };
 export type VerifyInfoIdentity = {
   iss?: string;

--- a/ui/src/components/VerifyStatus.tsx
+++ b/ui/src/components/VerifyStatus.tsx
@@ -11,7 +11,7 @@ const VerifyStatus: FC<Props> = ({ info }) => {
       <div className="largestatus">
         {info?.error ? (
           <>
-            <span className="status-bubble status-down"></span>
+            <span className="status-bubble status-down"> </span>
             <div className="title-wrapper">
               <span className="title">Identity verification failed</span>
               <label className="status-time">
@@ -20,6 +20,18 @@ const VerifyStatus: FC<Props> = ({ info }) => {
                   following error:{' '}
                 </span>
                 <code>{info?.error}</code>
+              </label>
+            </div>
+          </>
+        ) : !info?.request?.tlsValid ? (
+          <>
+            <span className="status-bubble status-warn"> </span>
+            <div className="title-wrapper">
+              <span className="title">TLS Certificate verification failed</span>
+              <label className="status-time">
+                <span>
+                  TLS certificate verification failed when verifying the JWT.
+                </span>
               </label>
             </div>
           </>

--- a/verify.go
+++ b/verify.go
@@ -7,25 +7,28 @@ import (
 
 	"cloud.google.com/go/firestore"
 	"github.com/go-chi/chi"
-	"github.com/pomerium/verify/internal/storage"
 	"github.com/rs/zerolog/log"
 	"golang.org/x/sync/errgroup"
+
+	"github.com/pomerium/verify/internal/storage"
 )
 
 // Server is the verify server backend.
 type Server struct {
 	cfg *config
 
-	http    *http.Server
-	router  chi.Router
-	storage storage.Backend
+	http        *http.Server
+	router      chi.Router
+	storage     storage.Backend
+	tlsVerifier *tlsVerifier
 }
 
 // New creates a new Server.
 func New(options ...Option) *Server {
 	cfg := getConfig(options...)
 	return &Server{
-		cfg: cfg,
+		cfg:         cfg,
+		tlsVerifier: newTLSVerifier(),
 	}
 }
 


### PR DESCRIPTION
Allow invalid certificates for HTTP requests. This will allow the verify app to work when using self-signed or custom certificates that aren't part of the root CA chain, while still providing information about TLS verification.

Fixes #70 