### PR TITLE
fix tls verifier

### DIFF
--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -6,7 +6,7 @@ export type VerifyInfoRequest = {
   method: string;
   origin: string;
   url: string;
-  tlsValid: boolean;
+  tlsError: string;
 };
 export type VerifyInfoIdentity = {
   iss?: string;

--- a/ui/src/components/VerifyStatus.tsx
+++ b/ui/src/components/VerifyStatus.tsx
@@ -23,14 +23,15 @@ const VerifyStatus: FC<Props> = ({ info }) => {
               </label>
             </div>
           </>
-        ) : !info?.request?.tlsValid ? (
+        ) : info?.request?.tlsError ? (
           <>
             <span className="status-bubble status-warn"> </span>
             <div className="title-wrapper">
               <span className="title">TLS Certificate verification failed</span>
               <label className="status-time">
                 <span>
-                  TLS certificate verification failed when verifying the JWT.
+                  TLS certificate verification failed when verifying the JWT:{' '}
+                  {info?.request?.tlsError}
                 </span>
               </label>
             </div>


### PR DESCRIPTION
The TLS verifier was checking the wrong server name. It should've been checking the server name of the issuer not the request to the verify app.

Also display the error in logs and on the page.

Fixes https://github.com/pomerium/internal/issues/1274