### PR TITLE
add JWT validation options

### DIFF
--- a/cmd/verify/main.go
+++ b/cmd/verify/main.go
@@ -31,6 +31,8 @@ func main() {
 		verify.WithBindAddress(addr),
 		verify.WithFirestoreProjectID(firestoreProjectID),
 		verify.WithJWKSEndpoint(jwksEndpoint),
+		verify.WithExpectedJWTIssuer(os.Getenv("EXPECTED_JWT_ISSUER")),
+		verify.WithExpectedJWTAudience(os.Getenv("EXPECTED_JWT_AUDIENCE")),
 	)
 	err := srv.Run(context.Background())
 	if err != nil {

--- a/config.go
+++ b/config.go
@@ -10,9 +10,11 @@ var (
 )
 
 type config struct {
-	bindAddress        string
-	firestoreProjectID string
-	jwksEndpoint       string
+	bindAddress         string
+	firestoreProjectID  string
+	jwksEndpoint        string
+	expectedJWTIssuer   string
+	expectedJWTAudience string
 }
 
 // An Option customizes the config.
@@ -29,6 +31,22 @@ func WithBindAddress(bindAddress string) Option {
 func WithJWKSEndpoint(jwksEndpoint string) Option {
 	return func(cfg *config) {
 		cfg.jwksEndpoint = jwksEndpoint
+	}
+}
+
+// WithExpectedJWTIssuer sets the expected JWT issuer claim in the config. If
+// set to the empty string, the issuer claim will not be validated.
+func WithExpectedJWTIssuer(issuer string) Option {
+	return func(cfg *config) {
+		cfg.expectedJWTIssuer = issuer
+	}
+}
+
+// WithExpectedJWTAudience sets the expected JWT audience claim in the config.
+// If set to the empty string, the audience claim will not be validated.
+func WithExpectedJWTAudience(audience string) Option {
+	return func(cfg *config) {
+		cfg.expectedJWTAudience = audience
 	}
 }
 

--- a/verify.go
+++ b/verify.go
@@ -61,7 +61,7 @@ func (srv *Server) init(ctx context.Context) error {
 		srv.storage = storage.NewInMemoryBackend()
 	}
 
-	srv.initRouter(srv.cfg.jwksEndpoint)
+	srv.initRouter()
 
 	srv.http = &http.Server{
 		Addr: srv.cfg.bindAddress,


### PR DESCRIPTION
Add environment variables EXPECTED_JWT_ISSUER and EXPECTED_JWT_AUDIENCE. When these are both unset or empty, no validation of the JWT issuer and audience claims is performed (this is the current behavior). When either variable is non-empty, the corresponding JWT claim is validated to match the value of that environment variable.