### PR TITLE
fix "Unsigned Identity Headers" table

### DIFF
--- a/ui/dist/index.css
+++ b/ui/dist/index.css
@@ -40,7 +40,6 @@ cite,
 code,
 dfn,
 em,
-strong,
 th,
 var,
 optgroup {

--- a/ui/src/components/VerifyHeaders.tsx
+++ b/ui/src/components/VerifyHeaders.tsx
@@ -13,7 +13,9 @@ const VerifyHeaders: FC<Props> = ({ info }) => {
       <div className="messages">
         <div className="box-inner">
           <div className="category-header clearfix">
-            <span className="category-title">Unsigned Identity Headers</span>
+            <span className="category-title">Unsigned Identity Headers
+              (<code>X-Pomerium-Claim-*</code>)
+            </span>
             <a href="/headers">
               <span className="json-icon"></span>
             </a>
@@ -27,7 +29,7 @@ const VerifyHeaders: FC<Props> = ({ info }) => {
                 </tr>
               </thead>
               <tbody>
-                {headers?.map(([k, vs]) => {
+                {headers?.map(([k, vs]) =>
                   <tr key={k}>
                     <td>{k}</td>
                     <td>
@@ -35,8 +37,8 @@ const VerifyHeaders: FC<Props> = ({ info }) => {
                         <p key={v}>{v}</p>
                       ))}
                     </td>
-                  </tr>;
-                })}
+                  </tr>
+                )}
               </tbody>
             </table>
           ) : (
@@ -49,7 +51,7 @@ const VerifyHeaders: FC<Props> = ({ info }) => {
             passing identity{' '}
           </a>{' '}
           to upstream applications as HTTP request headers. Note, unlike{' '}
-          <code>x-pomerium-jwt-assertion</code> these headers are
+          <code>X-Pomerium-Jwt-Assertion</code> these headers are{' '}
           <strong>not signed</strong>.
         </div>
       </div>


### PR DESCRIPTION
Fix a syntax issue that prevented the "Unsigned Identity Headers" table rows from displaying. (#161)

Update the description text for this section:
 - standardize the capitalization of X-Pomerium-Jwt-Assertion
 - add a missing space before "not signed"
 - restore the bold styling on "not signed"

Also add "(X-Pomerium-Claim-*)" to the section heading to emphasize that only custom claim headers starting with that prefix will be displayed here. (Custom claims can be configured to use arbitrary header names.)

Example screenshot:
<img width="665" alt="Screen Shot 2023-06-05 at 1 21 27 PM" src="https://github.com/pomerium/verify/assets/51246568/478bbe3c-acee-485f-8eed-6dbc95925b2b">
