### PR TITLE
verify/server: decrease timeout

### DIFF
--- a/http.go
+++ b/http.go
@@ -33,6 +33,7 @@ func (srv *Server) initRouter() {
 	transport.DialTLSContext = srv.tlsVerifier.DialTLSContext
 	client := &http.Client{
 		Transport: transport,
+		Timeout:   maxRemoteWait,
 	}
 
 	expected := &jwt.Expected{

--- a/tls.go
+++ b/tls.go
@@ -12,6 +12,8 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+const maxRemoteWait = 5 * time.Second
+
 type tlsVerifier struct {
 	mu     sync.Mutex
 	errors map[string]error
@@ -23,8 +25,8 @@ func newTLSVerifier() *tlsVerifier {
 
 func (v *tlsVerifier) DialTLSContext(ctx context.Context, network, addr string) (net.Conn, error) {
 	dialer := &net.Dialer{
-		Timeout:   30 * time.Second,
-		KeepAlive: 30 * time.Second,
+		Timeout:   maxRemoteWait,
+		KeepAlive: maxRemoteWait,
 		DualStack: true,
 	}
 	log.Info().Str("addr", addr).Msg("dialing")


### PR DESCRIPTION
Decrease the timeout from 30s to 5s.

Fixes https://github.com/pomerium/internal/issues/1576

