### PR TITLE
ui: resolve a React 18 warning

### DIFF
--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 
 import App from './components/App';
 
-ReactDOM.render(<App />, document.getElementById('main'));
+const root = createRoot(document.getElementById('main'));
+root.render(<App />);


### PR DESCRIPTION
Resolve a warning message about how "ReactDOM.render is no longer supported in React 18" according to the instructions at https://reactjs.org/link/switch-to-createroot.