### PR TITLE
Add support for custom CA certs

### DIFF
--- a/cmd/verify/main.go
+++ b/cmd/verify/main.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"context"
+	"encoding/csv"
 	"os"
+	"strings"
 
 	"github.com/rs/zerolog/log"
 
@@ -27,12 +29,22 @@ func main() {
 		firestoreProjectID = v
 	}
 
+	var extraCaCerts []string
+	if v, ok := os.LookupEnv("EXTRA_CA_CERTS"); ok {
+		var err error
+		extraCaCerts, err = csv.NewReader(strings.NewReader(v)).Read()
+		if err != nil {
+			log.Fatal().Err(err).Msg("failed to parse $EXTRA_CA_CERTS (expected comma-separated list of file paths)")
+		}
+	}
+
 	srv := verify.New(
 		verify.WithBindAddress(addr),
 		verify.WithFirestoreProjectID(firestoreProjectID),
 		verify.WithJWKSEndpoint(jwksEndpoint),
 		verify.WithExpectedJWTIssuer(os.Getenv("EXPECTED_JWT_ISSUER")),
 		verify.WithExpectedJWTAudience(os.Getenv("EXPECTED_JWT_AUDIENCE")),
+		verify.WithExtraCACerts(extraCaCerts...),
 	)
 	err := srv.Run(context.Background())
 	if err != nil {

--- a/config.go
+++ b/config.go
@@ -15,6 +15,7 @@ type config struct {
 	jwksEndpoint        string
 	expectedJWTIssuer   string
 	expectedJWTAudience string
+	extraCACerts        []string
 }
 
 // An Option customizes the config.
@@ -54,6 +55,15 @@ func WithExpectedJWTAudience(audience string) Option {
 func WithFirestoreProjectID(projectID string) Option {
 	return func(cfg *config) {
 		cfg.firestoreProjectID = projectID
+	}
+}
+
+// WithExtraCACerts adds paths to custom CA certificates to the config.
+// Certificates added with this option will be used in addition to the system
+// default pool.
+func WithExtraCACerts(paths ...string) Option {
+	return func(cfg *config) {
+		cfg.extraCACerts = append(cfg.extraCACerts, paths...)
 	}
 }
 


### PR DESCRIPTION
This adds a new environment variable 'EXTRA_CA_CERTS' which can contain a comma-separated list of file paths to CA certs. These certs will be used in addition to the system defaults.

- #146 