### PR TITLE
Add example Kubernetes manifests

### DIFF
--- a/examples/deployment-custom-ca.yaml
+++ b/examples/deployment-custom-ca.yaml
@@ -1,0 +1,90 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pomerium-verify
+  namespace: pomerium
+  labels:
+    app.kubernetes.io/name: pomerium-verify
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: pomerium-verify
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: pomerium-verify
+    spec:
+      containers:
+        - name: pomerium-verify
+          image: pomerium/verify:latest
+          env:
+            - name: PORT
+              value: "8000"
+            - name: EXTRA_CA_CERTS
+              value: /var/run/pomerium-verify/ca.crt
+          ports:
+            - name: http
+              protocol: TCP
+              containerPort: 8000
+          volumeMounts:
+            - name: pomerium-verify-ca-cert
+              mountPath: /var/run/pomerium-verify/
+              readOnly: true
+          resources:
+            requests:
+              cpu: 100m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8000
+            initialDelaySeconds: 2
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+      volumes:
+        - name: pomerium-verify-ca-cert
+          secret:
+            secretName: pomerium-verify-ca-cert
+            items:
+              - key: ca.crt
+                path: ca.crt
+            defaultMode: 0444
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pomerium-verify
+  namespace: pomerium
+spec:
+  selector:
+    app.kubernetes.io/name: pomerium-verify
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: 8000
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: pomerium-verify-ca-cert
+  namespace: pomerium
+type: Opaque
+data:
+  ca.crt: |
+    (your pem-encoded CA certificate)

--- a/examples/deployment.yaml
+++ b/examples/deployment.yaml
@@ -1,0 +1,66 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pomerium-verify
+  namespace: pomerium
+  labels:
+    app.kubernetes.io/name: pomerium-verify
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: pomerium-verify
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: pomerium-verify
+    spec:
+      containers:
+        - name: pomerium-verify
+          image: pomerium/verify:latest
+          env:
+            - name: PORT
+              value: "8000"
+          ports:
+            - name: http
+              protocol: TCP
+              containerPort: 8000
+          resources:
+            requests:
+              cpu: 100m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8000
+            initialDelaySeconds: 2
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pomerium-verify
+  namespace: pomerium
+spec:
+  selector:
+    app.kubernetes.io/name: pomerium-verify
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: 8000
+  type: ClusterIP

--- a/examples/ingress.yaml
+++ b/examples/ingress.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: verify
+  namespace: pomerium
+  annotations:
+    ingress.pomerium.io/pass_identity_headers: "true"
+    ingress.pomerium.io/allow_any_authenticated_user: "true"
+spec:
+  ingressClassName: pomerium
+  rules:
+    - host: verify.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: pomerium-verify
+                port:
+                  name: http

--- a/http.go
+++ b/http.go
@@ -63,6 +63,10 @@ func (srv *Server) initRouter() {
 	srv.router = chi.NewRouter()
 	srv.router.Use(sdk.AddIdentityToRequest(verifier))
 
+	srv.router.Get("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
 	// mount api
 	srv.router.Route("/api", func(r chi.Router) {
 		r.Use(middleware.NoCache)


### PR DESCRIPTION
This adds some example manifests that can be used to easily deploy the verify service in Kubernetes.

Additionally, a simple /healthz endpoint was added to support a readiness probe.