### PR TITLE
verify/ci: update lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,10 +17,10 @@ jobs:
 
       - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32
         with:
-          go-version: 1.22.x
+          go-version: 1.23.x
           cache: false
 
       - uses: golangci/golangci-lint-action@aaa42aa0628b4ae2578232a66b541047968fac86
         with:
-          version: v1.55
+          version: v1.60.1
           args: --timeout=10m

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.22.4
+golang 1.23.0


### PR DESCRIPTION
For https://github.com/pomerium/internal/issues/1835

Update golangci-lint to v1.60.1