### PR TITLE
fix broken link to JWT Claim Headers docs

### DIFF
--- a/ui/src/components/VerifyHeaders.tsx
+++ b/ui/src/components/VerifyHeaders.tsx
@@ -47,7 +47,7 @@ const VerifyHeaders: FC<Props> = ({ info }) => {
         </div>
         <div className="category-link">
           Pomerium allows{' '}
-          <a href="https://docs.pomerium.io/reference/#jwt-claim-headers">
+          <a href="https://www.pomerium.com/docs/reference/jwt-claim-headers">
             passing identity{' '}
           </a>{' '}
           to upstream applications as HTTP request headers. Note, unlike{' '}


### PR DESCRIPTION
Related issue:
https://linear.app/pomerium/issue/ENG-2589/standardize-on-pomeriumcom-for-websitedocs-urls